### PR TITLE
Exclude new `pfmx_` key prefix, currently only for `pfmx_comment`

### DIFF
--- a/build.py
+++ b/build.py
@@ -148,6 +148,8 @@ def process_subkeys(subkeys):
             continue
         if name.lower().startswith("pfc_"):
             continue
+        if name.lower().startswith("pfmx_"):
+            continue
 
         # Skip specific types
         ignored_types = ("data",)


### PR DESCRIPTION
Per https://github.com/ProfileCreator/ProfileManifests/issues/567 & https://github.com/ProfileCreator/ProfileManifests/pull/609, believe this is all that's needed to exclude the new `pfmx_comment` key.

LMK if this is incorrect, or if there's more that's needed to be done here :)