### PR TITLE
Update io.tailscale.ipn.macos.json

### DIFF
--- a/manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.json
+++ b/manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.json
@@ -224,7 +224,7 @@
             },
             "property_order": 65
         },
-        "Hidden network devices": {
+        "HiddenNetworkDevices": {
             "type": "array",
             "items": {
                 "type": "string",


### PR DESCRIPTION
The option to hide network devices was not working, I opened a ticket with Tailscale and we found the issue to be a syntax error. The policy key was "Hidden network devices" where it should be "HiddenNetworkDevices" as specified here: https://tailscale.com/kb/1315/mdm-keys#hide-network-devices